### PR TITLE
Add support for passing `function_params` as `PyDict`

### DIFF
--- a/crates/grpo_rewards/src/lib.rs
+++ b/crates/grpo_rewards/src/lib.rs
@@ -3,7 +3,7 @@ use pyo3::{exceptions::PyTypeError, exceptions::PyValueError, prelude::*};
 use std::collections::HashMap;
 
 trait Calculator: Send + Sync {
-    fn new() -> Self
+    fn new(params: HashMap<String, String>) -> Self
     where
         Self: Sized;
 
@@ -32,7 +32,7 @@ pub struct GrpoRewards {
 struct CompletionNegativeLengthCalculator;
 
 impl Calculator for CompletionNegativeLengthCalculator {
-    fn new() -> Self {
+    fn new(_params: HashMap<String, String>) -> Self {
         CompletionNegativeLengthCalculator
     }
 
@@ -71,7 +71,7 @@ fn convert_pydict_to_str2str_map(d: Option<&Bound<'_, PyDict>>) -> HashMap<Strin
                 (key, value)
             })
             .collect();
-        x
+        Some(x)
     } else {
         HashMap::new()
     }
@@ -95,13 +95,15 @@ impl GrpoRewards {
             ));
         }
 
-        let _internal_func_params = convert_pydict_to_str2str_map(function_params);
+        let internal_func_params = convert_pydict_to_str2str_map(function_params);
 
         // TODO Refactor into calculator builder function.
         let calculator: Box<dyn Calculator>;
         match function_name {
             "CompletionNegativeLengthCalculator" => {
-                calculator = Box::new(CompletionNegativeLengthCalculator::new())
+                calculator = Box::new(CompletionNegativeLengthCalculator::new(
+                    internal_func_params,
+                ))
             }
             _ => return Err(PyValueError::new_err("Unknown calculator.")),
         }

--- a/crates/grpo_rewards/src/lib.rs
+++ b/crates/grpo_rewards/src/lib.rs
@@ -1,4 +1,5 @@
-use pyo3::{exceptions::PyValueError, prelude::*};
+use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
+use std::collections::HashMap;
 
 trait Calculator: Send + Sync {
     fn new() -> Self
@@ -50,7 +51,13 @@ impl Calculator for CompletionNegativeLengthCalculator {
 #[pymethods]
 impl GrpoRewards {
     #[new]
-    fn new(function_name: &str, prompts: Vec<String>, completions: Vec<String>) -> PyResult<Self> {
+    #[pyo3(signature = (function_name, prompts, completions, **function_kwargs))]
+    fn new(
+        function_name: &str,
+        prompts: Vec<String>,
+        completions: Vec<String>,
+        function_kwargs: Option<&PyDict>,
+    ) -> PyResult<Self> {
         if completions.is_empty() {
             return Err(PyValueError::new_err("Completions cannot be empty."));
         } else if !prompts.is_empty() && (prompts.len() != completions.len()) {
@@ -58,6 +65,11 @@ impl GrpoRewards {
                 "Prompts and completions must have the same length.",
             ));
         }
+
+        let options: HashMap<&str, &PyAny> = match kwargs {
+            Some(py_dict) => py_dict.extract()?,
+            None => HashMap::new(),
+        };
 
         // TODO Refactor into calculator builder function.
         let calculator: Box<dyn Calculator>;

--- a/crates/grpo_rewards/src/lib.rs
+++ b/crates/grpo_rewards/src/lib.rs
@@ -33,7 +33,6 @@ struct CompletionNegativeLengthCalculator;
 
 impl Calculator for CompletionNegativeLengthCalculator {
     fn new(params: HashMap<String, String>) -> Self {
-        println!("CompletionNegativeLengthCalculator: {:?}", params);
         CompletionNegativeLengthCalculator
     }
 

--- a/crates/grpo_rewards/src/lib.rs
+++ b/crates/grpo_rewards/src/lib.rs
@@ -1,4 +1,5 @@
-use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
+use pyo3::types::PyDict;
+use pyo3::{exceptions::PyTypeError, exceptions::PyValueError, prelude::*};
 use std::collections::HashMap;
 
 trait Calculator: Send + Sync {
@@ -48,15 +49,43 @@ impl Calculator for CompletionNegativeLengthCalculator {
     }
 }
 
+fn convert_pydict_to_str2str_map(d: Option<&Bound<'_, PyDict>>) -> HashMap<String, String> {
+    if let Some(params) = d {
+        let x: HashMap<String, String> = params
+            .iter()
+            .map(|(key, value)| {
+                let key: String = key
+                    .str()
+                    .map_err(|_| {
+                        PyTypeError::new_err("function_params's key is not convertible to string")
+                    })
+                    .unwrap()
+                    .to_string();
+                let value: String = value
+                    .str()
+                    .map_err(|_| {
+                        PyTypeError::new_err("function_params's value is not convertible to string")
+                    })
+                    .unwrap()
+                    .to_string();
+                (key, value)
+            })
+            .collect();
+        x
+    } else {
+        HashMap::new()
+    }
+}
+
 #[pymethods]
 impl GrpoRewards {
     #[new]
-    #[pyo3(signature = (function_name, prompts, completions, **function_kwargs))]
-    fn new(
+    #[pyo3(signature = (function_name, prompts, completions, function_params=None))]
+    fn py_new(
         function_name: &str,
         prompts: Vec<String>,
         completions: Vec<String>,
-        function_kwargs: Option<&PyDict>,
+        function_params: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Self> {
         if completions.is_empty() {
             return Err(PyValueError::new_err("Completions cannot be empty."));
@@ -66,10 +95,7 @@ impl GrpoRewards {
             ));
         }
 
-        let options: HashMap<&str, &PyAny> = match kwargs {
-            Some(py_dict) => py_dict.extract()?,
-            None => HashMap::new(),
-        };
+        let _internal_func_params = convert_pydict_to_str2str_map(function_params);
 
         // TODO Refactor into calculator builder function.
         let calculator: Box<dyn Calculator>;

--- a/crates/grpo_rewards/src/lib.rs
+++ b/crates/grpo_rewards/src/lib.rs
@@ -71,7 +71,7 @@ fn convert_pydict_to_str2str_map(d: Option<&Bound<'_, PyDict>>) -> HashMap<Strin
                 (key, value)
             })
             .collect();
-        Some(x)
+        x
     } else {
         HashMap::new()
     }

--- a/crates/grpo_rewards/src/lib.rs
+++ b/crates/grpo_rewards/src/lib.rs
@@ -32,7 +32,8 @@ pub struct GrpoRewards {
 struct CompletionNegativeLengthCalculator;
 
 impl Calculator for CompletionNegativeLengthCalculator {
-    fn new(_params: HashMap<String, String>) -> Self {
+    fn new(params: HashMap<String, String>) -> Self {
+        println!("CompletionNegativeLengthCalculator: {:?}", params);
         CompletionNegativeLengthCalculator
     }
 
@@ -80,7 +81,7 @@ fn convert_pydict_to_str2str_map(d: Option<&Bound<'_, PyDict>>) -> HashMap<Strin
 #[pymethods]
 impl GrpoRewards {
     #[new]
-    #[pyo3(signature = (function_name, prompts, completions, function_params=None))]
+    #[pyo3(signature = (function_name, prompts, completions, *, function_params=None))]
     fn py_new(
         function_name: &str,
         prompts: Vec<String>,

--- a/crates/grpo_rewards/src/lib.rs
+++ b/crates/grpo_rewards/src/lib.rs
@@ -32,7 +32,7 @@ pub struct GrpoRewards {
 struct CompletionNegativeLengthCalculator;
 
 impl Calculator for CompletionNegativeLengthCalculator {
-    fn new(params: HashMap<String, String>) -> Self {
+    fn new(_params: HashMap<String, String>) -> Self {
         CompletionNegativeLengthCalculator
     }
 
@@ -49,31 +49,30 @@ impl Calculator for CompletionNegativeLengthCalculator {
     }
 }
 
-fn convert_pydict_to_str2str_map(d: Option<&Bound<'_, PyDict>>) -> HashMap<String, String> {
+fn convert_pydict_to_str2str_map(
+    d: Option<&Bound<'_, PyDict>>,
+) -> anyhow::Result<HashMap<String, String>> {
     if let Some(params) = d {
-        let x: HashMap<String, String> = params
-            .iter()
-            .map(|(key, value)| {
-                let key: String = key
-                    .str()
-                    .map_err(|_| {
-                        PyTypeError::new_err("function_params's key is not convertible to string")
-                    })
-                    .unwrap()
-                    .to_string();
-                let value: String = value
-                    .str()
-                    .map_err(|_| {
-                        PyTypeError::new_err("function_params's value is not convertible to string")
-                    })
-                    .unwrap()
-                    .to_string();
-                (key, value)
-            })
-            .collect();
-        x
+        let mut x: HashMap<String, String> = HashMap::with_capacity(params.len());
+
+        for (key, value) in params.iter() {
+            let key: String = key
+                .str()
+                .map_err(|_| {
+                    PyTypeError::new_err("function_params's key is not convertible to string")
+                })?
+                .to_string();
+            let value: String = value
+                .str()
+                .map_err(|_| {
+                    PyTypeError::new_err("function_params's value is not convertible to string")
+                })?
+                .to_string();
+            x.insert(key, value);
+        }
+        Ok(x)
     } else {
-        HashMap::new()
+        Ok(HashMap::new())
     }
 }
 
@@ -95,7 +94,7 @@ impl GrpoRewards {
             ));
         }
 
-        let internal_func_params = convert_pydict_to_str2str_map(function_params);
+        let internal_func_params = convert_pydict_to_str2str_map(function_params)?;
 
         // TODO Refactor into calculator builder function.
         let calculator: Box<dyn Calculator>;


### PR DESCRIPTION
-- Minor generalization in the library API.
-- Add internal helper function to convert PyDict to HashMap<String, String> (`PyDict`/`PyAny` is general but hard to use)

Towards OPE-1121