### PR TITLE
feat(sampler): add trait and core sampling implementations 

### DIFF
--- a/crates/data_preparation/src/lib.rs
+++ b/crates/data_preparation/src/lib.rs
@@ -4,6 +4,7 @@ pub mod minibatch;
 pub mod readers;
 pub mod sample;
 pub mod transforms;
+pub mod sampler; 
 
 pub use collator::StackCollator;
 pub use dataset::Dataset;
@@ -11,3 +12,4 @@ pub use dataset::InMemoryDataset;
 pub use minibatch::MiniBatch;
 pub use sample::Sample;
 pub use transforms::Transform;
+pub use sampler::Sampler; 

--- a/crates/data_preparation/src/lib.rs
+++ b/crates/data_preparation/src/lib.rs
@@ -3,13 +3,13 @@ pub mod dataset;
 pub mod minibatch;
 pub mod readers;
 pub mod sample;
+pub mod sampler;
 pub mod transforms;
-pub mod sampler; 
 
 pub use collator::StackCollator;
 pub use dataset::Dataset;
 pub use dataset::InMemoryDataset;
 pub use minibatch::MiniBatch;
 pub use sample::Sample;
+pub use sampler::Sampler;
 pub use transforms::Transform;
-pub use sampler::Sampler; 

--- a/crates/data_preparation/src/sampler.rs
+++ b/crates/data_preparation/src/sampler.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 /// Implementations must be `Send + Sync` so the same sampler instance can be
 /// safely shared across DataLoader worker threads.
 pub trait Sampler: Send + Sync {
-    type Item;
+    type Item: Send + Sync;
 
     fn iter(&self, epoch: usize) -> Box<dyn Iterator<Item = Self::Item> + Send + '_>;
 }

--- a/crates/data_preparation/src/sampler.rs
+++ b/crates/data_preparation/src/sampler.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 ///      a custom handle like `(shard, offset)`.
 ///
 /// # Method
-/// - `iter(epoch)`: returns a shuffled sequence for that epoch.
+/// - `iter(epoch)`: returns a sequential or shuffled sequence for that epoch.
 ///    - Users pass the `epoch` parameter so internally the sampler uses it
 ///      together with the base RNG seed to shuffle in a reproducible way across epochs.
 ///

--- a/crates/data_preparation/src/sampler.rs
+++ b/crates/data_preparation/src/sampler.rs
@@ -1,21 +1,21 @@
-/// A `Sampler` defines the strategy for how to iterate and draw samples from 
-/// a dataset. 
-/// 
+/// A `Sampler` defines the strategy for how to iterate and draw samples from
+/// a dataset.
+///
 /// # Associated type
-/// - `Item`: The handle yielded by the iterator 
+/// - `Item`: The handle yielded by the iterator
 ///    - For in-memory datasets this is a `usize` index
-///    - For streaming datasets it could be just the next item `()` or 
-///      a custom handle like `(shard, offset)`. 
-/// 
-/// # Method 
-/// - `iter(epoch)`: returns a shuffled sequence for that epoch. 
-///    - Users pass the `epoch` parameter so internally the sampler uses it 
-///      together with the base seed to shuffle in a reproducible way across epochs. 
-/// 
-/// Implementations must be `Send + Sync` so the same sampler instance can be 
-/// safely shared across DataLoader worker threads. 
+///    - For streaming datasets it could be just the next item `()` or
+///      a custom handle like `(shard, offset)`.
+///
+/// # Method
+/// - `iter(epoch)`: returns a shuffled sequence for that epoch.
+///    - Users pass the `epoch` parameter so internally the sampler uses it
+///      together with the base seed to shuffle in a reproducible way across epochs.
+///
+/// Implementations must be `Send + Sync` so the same sampler instance can be
+/// safely shared across DataLoader worker threads.
 pub trait Sampler: Send + Sync {
-    type Item; 
+    type Item;
 
     fn iter(&self, epoch: usize) -> Box<dyn Iterator<Item = Self::Item> + Send + '_>;
 }

--- a/crates/data_preparation/src/sampler.rs
+++ b/crates/data_preparation/src/sampler.rs
@@ -1,3 +1,7 @@
+use anyhow::{ensure, Result};
+use rand::seq::SliceRandom;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
 /// A `Sampler` defines the strategy for how to iterate and draw samples from
 /// a dataset.
 ///
@@ -32,6 +36,7 @@ pub trait Sampler: Send + Sync {
 /// let indices: Vec<_> = sampler.iter(0).collect();
 /// assert_eq!(indices, vec![0, 1, 2, 3, 4]);
 /// ```
+#[derive(Debug, Clone)]
 pub struct SequentialSampler {
     dataset_size: usize,
 }
@@ -47,6 +52,110 @@ impl Sampler for SequentialSampler {
 
     fn iter(&self, _epoch: usize) -> Box<dyn Iterator<Item = usize> + Send + '_> {
         Box::new(0..self.dataset_size)
+    }
+}
+
+/// ============================================================================
+/// Random uniform sampling over `0..dataset_size`, with optional replacement.
+///
+/// # Arguments:
+/// - `dataset_size`: Total number of samples in a dataset.
+/// - `replacement`: If `true`, each draw is independent and indices may repeat;
+///                  If `false`, each index can only appear once.
+/// - `num_samples`: Number of samples to draw from (defaults to the full-range `dataset_size` if `None`)
+///                  If `replacement=false`, users must have num_samples <= dataset_size.
+/// - `base_seed`: Master seed.
+///
+/// # Seed Handling
+/// 1. Seeds matter because:
+/// - Fixed seed -> Identical order every run (good for reproducibility)
+/// - Varying seed -> Better model generalization (sees data in different orders)
+///
+/// # Design rationale
+/// 1. Per-epoch variation
+/// - For each epoch, we derive a new RNG as `base_seed + epoch`. So at epoch = 0, the RNG = base_seed;
+///   At epoch = 1, the RNG = base_seed + 1.
+/// - Benefits:
+///   - Fresh shuffle each epoch (better training)
+///   - Still reproducible with the same `base_seed`.
+///
+/// 2. Multi-worker safety
+/// - For multi-worker setups, the DataLoader initializes a separate `RandomSampler` instance per worker.
+/// - The DataLoader provides each instance with a distinct `base_seed` (typically `global_seed + worker_id`).
+/// - So the resulting RNG seed for each worker at each epoch is: `(global_seed + worker_id) + epoch`
+/// - This prevents duplicate samples across workers and biased gradient updates.
+/// - Note: The sampler itself does not manage worker_id. Worker coordination is handled by `DataLoader`.
+///
+/// 3. For further reading, please refer to this notebook on seeds and determinism:
+///    https://gist.github.com/NicolasHug/96a75c2d754ff2a7c52afca2c0b628d4
+///
+/// # Example usage
+/// ```ignore
+/// // Without replacement
+/// let sampler1 = RandomSampler::new(1000, false, None, 42)?;
+///
+/// // With replacement
+/// let sampler2 = RandomSampler::new(1000, true, None, 42)?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct RandomSampler {
+    dataset_size: usize,
+    replacement: bool,
+    num_samples: usize,
+    base_seed: u64,
+}
+
+impl RandomSampler {
+    pub fn new(
+        dataset_size: usize,
+        replacement: bool,
+        num_samples: Option<usize>,
+        base_seed: u64,
+    ) -> Result<Self> {
+        let num_samples = num_samples.unwrap_or(dataset_size);
+        ensure!(
+            num_samples > 0,
+            "num_samples must be a positive integer value, but got num_samples={}",
+            num_samples
+        );
+
+        if !replacement {
+            ensure!(
+                num_samples <= dataset_size,
+                "num_samples ({}) exceeds dataset size ({}) without replacement",
+                num_samples,
+                dataset_size
+            );
+        }
+
+        Ok(Self {
+            dataset_size,
+            replacement,
+            num_samples,
+            base_seed,
+        })
+    }
+
+    /// Derives a deterministic random number generator for the given epoch
+    #[inline]
+    fn derive_rng_for_epoch(&self, epoch: usize) -> StdRng {
+        StdRng::seed_from_u64(self.base_seed.wrapping_add(epoch as u64))
+    }
+}
+
+impl Sampler for RandomSampler {
+    type Item = usize;
+
+    fn iter(&self, epoch: usize) -> Box<dyn Iterator<Item = usize> + Send + '_> {
+        let mut rng = self.derive_rng_for_epoch(epoch);
+        if self.replacement {
+            Box::new((0..self.num_samples).map(move |_| rng.random_range(0..self.dataset_size)))
+        } else {
+            let mut indices: Vec<_> = (0..self.dataset_size).collect();
+            indices.shuffle(&mut rng);
+            indices.truncate(self.num_samples);
+            Box::new(indices.into_iter())
+        }
     }
 }
 
@@ -83,6 +192,48 @@ mod tests {
             let sampler = SequentialSampler::new(dataset.len());
             let indices: Vec<usize> = sampler.iter(0).collect();
             assert_eq!(indices, (0..100).collect::<Vec<_>>());
+        }
+    }
+
+    mod random_sampler_tests {
+        use super::*;
+        use std::collections::HashSet;
+
+        const TEST_SEED: u64 = 42;
+        const TEST_DATASET_SIZE: usize = 100;
+
+        #[test]
+        fn validates_parameters() {
+            assert!(RandomSampler::new(10, false, None, TEST_SEED).is_ok());
+
+            // Invalid initialization: empty dataset and nothing to sample from
+            assert!(RandomSampler::new(0, false, None, TEST_SEED).is_err());
+
+            // Invalid initialization: `num_samples` > `dataset_size` when `replacement = false`
+            assert!(RandomSampler::new(10, false, Some(11), TEST_SEED).is_err());
+        }
+
+        #[test]
+        fn without_replacement_contains_all_indices() {
+            let sampler = RandomSampler::new(TEST_DATASET_SIZE, false, None, TEST_SEED).unwrap();
+            let samples: Vec<_> = sampler.iter(0).collect();
+            assert_eq!(samples.len(), TEST_DATASET_SIZE);
+            assert_eq!(HashSet::<_>::from_iter(samples).len(), TEST_DATASET_SIZE);
+        }
+
+        #[test]
+        fn with_replacement_allows_duplicates() {
+            let sampler = RandomSampler::new(10, true, Some(100), TEST_SEED).unwrap();
+            let samples: Vec<_> = sampler.iter(0).collect();
+            assert!(HashSet::<_>::from_iter(&samples).len() < 100);
+        }
+
+        #[test]
+        fn produces_deterministic_results() {
+            let sampler = RandomSampler::new(TEST_DATASET_SIZE, false, None, TEST_SEED).unwrap();
+            let epoch1 = sampler.iter(1).collect::<Vec<_>>();
+            assert_eq!(epoch1, sampler.iter(1).collect::<Vec<_>>());
+            assert_ne!(epoch1, sampler.iter(2).collect::<Vec<_>>());
         }
     }
 }

--- a/crates/data_preparation/src/sampler.rs
+++ b/crates/data_preparation/src/sampler.rs
@@ -303,6 +303,15 @@ impl WeightedRandomSampler {
             num_samples,
             dataset_size,
         );
+        if !replacement {
+            let positive_count = weights.iter().filter(|&&w| w > 0.0).count();
+            ensure!(
+                num_samples <= positive_count,
+                "num_samples ({}) must be <= number of positive-weight indices ({}) when replacement = false",
+                num_samples,
+                positive_count,
+            );
+        }
 
         Ok(Self {
             _dataset_size: dataset_size,

--- a/crates/data_preparation/src/sampler.rs
+++ b/crates/data_preparation/src/sampler.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 /// # Method
 /// - `iter(epoch)`: returns a shuffled sequence for that epoch.
 ///    - Users pass the `epoch` parameter so internally the sampler uses it
-///      together with the base seed to shuffle in a reproducible way across epochs.
+///      together with the base RNG seed to shuffle in a reproducible way across epochs.
 ///
 /// Implementations must be `Send + Sync` so the same sampler instance can be
 /// safely shared across DataLoader worker threads.
@@ -66,7 +66,7 @@ impl Sampler for SequentialSampler {
 ///                  If `false`, each index can only appear once.
 /// - `num_samples`: Number of samples to draw from (defaults to the full-range `dataset_size` if `None`)
 ///                  If `replacement=false`, users must have num_samples <= dataset_size.
-/// - `base_seed`: Master seed.
+/// - `base_seed`: Base RNG seed.
 ///
 /// # Seed Handling
 /// 1. Seeds matter because:
@@ -171,7 +171,7 @@ impl Sampler for RandomSampler {
 /// - `dataset_size`: Total number of samples in a dataset.
 /// - `indices`: The subset of indices to shuffle and sample from. There should be
 ///              no duplicates and each index should be within bounds (`<dataset_size`).
-/// - `base_seed`: Master seed.
+/// - `base_seed`: Base RNG seed.
 ///
 /// # Example
 /// ```ignore
@@ -239,7 +239,7 @@ impl Sampler for SubsetRandomSampler {
 ///                  If `false`, each index can only appear once.
 /// - `num_samples`: Number of samples to draw from (defaults to the full-range `dataset_size` if `None`)
 ///                  If `replacement=false`, users must have num_samples <= dataset_size.
-/// - `base_seed`: Master seed. See `RandomSampler` docs for details.
+/// - `base_seed`: Base RNG seed. See `RandomSampler` docs for details.
 ///
 /// # Example
 /// ```ignore
@@ -460,7 +460,7 @@ impl<S: Sampler> Sampler for BatchSampler<S> {
 /// # Arguments:
 /// - `shards`: The list of shard handles to iterate.
 /// - `shuffle`: Whether to shuffle the order every epoch.
-/// - `base_seed`: Master seed.
+/// - `base_seed`: Base RNG seed.
 ///
 /// # Example
 /// ```ignore
@@ -472,7 +472,7 @@ impl<S: Sampler> Sampler for BatchSampler<S> {
 ///         PathBuf::from("data/part2.parquet"),
 ///     ],
 ///     false, // shuffle
-///     123, // base seed
+///     123, // base RNG seed
 /// );
 ///
 /// // Shuffled iteration over S3 URIs
@@ -529,7 +529,7 @@ impl<H: Clone + Send + Sync> Sampler for ShardSampler<H> {
 /// - `drop_last`: If true, any extra indices beyond an exact multiple of `num_replicas` are dropped.
 ///                If false, the list of indices is padded by cycling from the front until its length
 ///                is evenly divisible among workers.
-/// - `base_seed`: Master seed shared by all workers.
+/// - `base_seed`: Base RNG seed shared by all workers.
 ///
 /// # Worker allocation
 /// - For dataset with 10 samples across 3 workers:
@@ -678,7 +678,7 @@ impl Sampler for DistributedSampler {
 ///               Sorted in descending order: higher key ⇒ earlier in bucket.
 /// - `bucket_size_multiplier`: Multiplier for bucket size. Each bucket’s size is
 ///                             `batch_size * bucket_size_multiplier`. Must be ≥ 1.
-/// - `base_seed`: Master RNG seed for deterministic shuffling.
+/// - `base_seed`: Base RNG seed for deterministic shuffling.
 ///
 /// # Algorithm Overview
 /// 1. Pre-bucketing
@@ -709,7 +709,7 @@ impl Sampler for DistributedSampler {
 /// // 2. Groups indices into buckets of size = 32 * 100 = 3200.
 /// // 3. Sorts each bucket by length (descending).
 /// // 4. Splits into mini‐batches of size 32 (dropping any remainder if `drop_last` is true).
-/// // 5. Shuffles the resulting mini‐batches using a deterministic seed.
+/// // 5. Shuffles the resulting mini‐batches using a deterministic RNG seed.
 /// let sampler = BatchBucketSampler::new(
 ///     SequentialSampler::new(texts.len()),  // base sampler
 ///     32,                                   // batch_size

--- a/crates/data_preparation/src/sampler.rs
+++ b/crates/data_preparation/src/sampler.rs
@@ -19,3 +19,70 @@ pub trait Sampler: Send + Sync {
 
     fn iter(&self, epoch: usize) -> Box<dyn Iterator<Item = Self::Item> + Send + '_>;
 }
+
+/// ============================================================================
+/// Yields indices sequentially in order `(0,1,2,...,dataset_size-1)`.
+///
+/// # Arguments:
+/// - `dataset_size`: Total number of samples in a dataset
+///
+/// # Examples
+/// ```ignore
+/// let sampler = SequentialSampler::new(5);
+/// let indices: Vec<_> = sampler.iter(0).collect();
+/// assert_eq!(indices, vec![0, 1, 2, 3, 4]);
+/// ```
+pub struct SequentialSampler {
+    dataset_size: usize,
+}
+
+impl SequentialSampler {
+    pub fn new(dataset_size: usize) -> Self {
+        Self { dataset_size }
+    }
+}
+
+impl Sampler for SequentialSampler {
+    type Item = usize;
+
+    fn iter(&self, _epoch: usize) -> Box<dyn Iterator<Item = usize> + Send + '_> {
+        Box::new(0..self.dataset_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataset::InMemoryDataset;
+    use crate::sample::Sample;
+    use tch::Tensor;
+
+    mod sequential_sampler_tests {
+        use super::*;
+
+        #[test]
+        fn yields_sequential_indices() {
+            let sampler = SequentialSampler::new(100);
+            let indices: Vec<usize> = sampler.iter(0).collect();
+            assert_eq!(indices, (0..100).collect::<Vec<_>>());
+        }
+
+        #[test]
+        fn handles_empty_dataset() {
+            let sampler = SequentialSampler::new(0);
+            assert_eq!(sampler.iter(0).count(), 0);
+        }
+
+        #[test]
+        fn works_with_inmemory_dataset() {
+            let samples: Vec<Sample> = (0..100)
+                .map(|i| Sample::from_single("data", Tensor::from(i)))
+                .collect();
+            let dataset = InMemoryDataset::new(samples);
+
+            let sampler = SequentialSampler::new(dataset.len());
+            let indices: Vec<usize> = sampler.iter(0).collect();
+            assert_eq!(indices, (0..100).collect::<Vec<_>>());
+        }
+    }
+}

--- a/crates/data_preparation/src/sampler.rs
+++ b/crates/data_preparation/src/sampler.rs
@@ -1,0 +1,21 @@
+/// A `Sampler` defines the strategy for how to iterate and draw samples from 
+/// a dataset. 
+/// 
+/// # Associated type
+/// - `Item`: The handle yielded by the iterator 
+///    - For in-memory datasets this is a `usize` index
+///    - For streaming datasets it could be just the next item `()` or 
+///      a custom handle like `(shard, offset)`. 
+/// 
+/// # Method 
+/// - `iter(epoch)`: returns a shuffled sequence for that epoch. 
+///    - Users pass the `epoch` parameter so internally the sampler uses it 
+///      together with the base seed to shuffle in a reproducible way across epochs. 
+/// 
+/// Implementations must be `Send + Sync` so the same sampler instance can be 
+/// safely shared across DataLoader worker threads. 
+pub trait Sampler: Send + Sync {
+    type Item; 
+
+    fn iter(&self, epoch: usize) -> Box<dyn Iterator<Item = Self::Item> + Send + '_>;
+}


### PR DESCRIPTION
This PR implements the `Sampler` abstraction to control how data is iterated over - whether sequentially, randomly, or distributed across workers. 

## 1. Sampler Trait 
```rust
pub trait Sampler: Send + Sync {
    type Item: Send + Sync;  
    fn iter(&self, epoch: usize) -> Box<dyn Iterator<Item = Self::Item> + Send + '_>;
}
```
**Design Choices:**
- **Thread-safe** (`Send + Sync`) for use in multi-threaded `DataLoader`. 
- **Generic** `Item` supports both indices (`usize`) and shard handles (e.g., `PathBuf`)
- **Epoch-aware:** The `epoch` parameter in `iter` ensures deterministic shuffling across training runs

**Alternatives considered:** 
- `set_epoch(epoch)` + `iter()`, but this complicates distributed synchronization. 
- `iter(epoch)` keeps the API stateless and dead-lock-free in async contexts. 


## 2. Seed Handling 
**Why it matters:**
- **Fixed seed**: Ensures reproducibility (e.g., for debugging) 
- **Varying seed**: Improves model generalization by shuffling data differently per epoch and across workers. 
- So for this PR, the RNG seed is derived as: 
    ```rust 
    // Worker `rank` at epoch `e`:
   let seed = base_seed
        .wrapping_add(e as u64)      // vary by epoch
        .wrapping_add(rank as u64);  // vary by worker
    let rng  = StdRng::seed_from_u64(seed);
    ```

**Integration with** forthcoming `DataLoader`: 
- If `shuffle = True`, the loader will forward the current training epoch into iter(epoch) of the sampler , producing a new shuffle each epoch.
- If `shuffle = False`, the loader always calls iter(0) for the sampler, yielding a fixed, unshuffled order regardless of the outer epoch.

## 3. Implemented Samplers

| Sampler                | Key Functionality        | Output Type     |
|------------------------|--------------------------|-----------------|
| `SequentialSampler`    | In-order iteration       | `usize`         |
| `RandomSampler`        | Uniform shuffling        | `usize`         |
| `SubsetRandomSampler`  | Subset shuffling         | `usize`         |
| `WeightedRandomSampler`| Importance sampling      | `usize`         |
| `ShardSampler`         | File/URL iteration       | `PathBuf / String`|
| `DistributedSampler`   | Multi-worker partitioning| `usize`         |
| `BatchBucketSampler`   | Length-based batching    | `Vec<usize>`    |
| `BatchSampler`         | Generic batching wrapper | `Vec<T>`        |

**Note:**

* `ShardSampler` is the only sampler that returns non-`usize` items (e.g., `PathBuf`).
* Others assume `InMemoryDataset`-style index access.

## 4. Integration Examples: 
With `InMemoryDataset`: 
```rust
let dataset = InMemoryDataset::new(data);
let sampler = RandomSampler::new(dataset.len(), false, None, 42)?;
for idx in sampler.iter(0) {  // Epoch 0
    let sample = dataset.get(idx)?;
    // ...
}
```

With `IterableDataset`: 
```rust
let shards = vec![shard1, shard2];  // e.g., file paths
let sampler = ShardSampler::new(shards, true, 42)?;  // Shuffle shards
let dataset = IterableDataset::new(sampler.iter(0).map(|p| TxtSource::new(p)));
```

## 5. Testing Coverage: 
- Correctness:
   - Indices are unique/no duplicates (when replacement=false).
   - Distributed partitions are disjoint.
   - Bucket batches group similar-length items.
- Determinism:
   - Same seed + epoch → identical order.
   - Different seeds/epochs → different order.
- Edge Cases:
   - Empty datasets, zero weights, partial batches. 

## 6. Future work
1. Implement `DataLoader` 
2. Benchmark profile 
3. Performance tweaks 
   * Priority queue for `BatchBucketSampler` (if bucket sizes > 100k)
   * Async prefetching in `ShardSampler` (HTTP/S3/tar). 
